### PR TITLE
Ensure stable serialization format

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ const barSize = ulong.sizeof + float.sizeof + ubyte.sizeof +
 assert(bar.sbinSerialize.length == barSize);
 ```
 
+### Stable binary format across minor releases
+
+If you use sbin to serialize data to and from file, you will be interested
+to maintain stability in the binary serialization format, so that files saved
+with older versions of your softare can be opened in newer versions. Sbin has
+been using the same format since release 0.5.0, and will continue doing so at
+least until the major version number is bumped. It is therefore safe to allow
+dub to do minor version upgrades with a version specification like `~>0.8`,
+equivalent to ">=0.8.0 <1.0.0".
+
+If, in the future, changes to the format are made, then sbin will provide a 
+variant of `sbinDeserialize` that supports the older format(s). This will be
+mentioned in the release notes.
+
+However, it will be up to the application programmer (you) to call the correct
+variant of `sbinDeserialize`. You are therefore advised to **save your files
+with a file header** from which you will always be able to derive the format
+version with which the succeeding bytes should be deserialized.
+
+(Of course the major version number *may* be bumped without changing the format.)
+
 ### Skipping fields
 
 If a field in a struct has the `@sbinSkip` attribute, the field will

--- a/example/all_example.d
+++ b/example/all_example.d
@@ -76,6 +76,9 @@ void barTest()
         byte.sizeof + 1 /+ length packed to 1 byte +/ + 1 + // Foo
         byte.sizeof /+ length packed to 1 byte +/ // null
     );
+    assert (sdbar_data == [123, 0, 0, 0, 4, 1, 42, 0, 0, 0, 2, 3, 111, 110, 101, 3, 1, 65,
+                           0, 3, 0, 43, 0, 0, 0, 1, 3, 116, 119, 111, 2, 1, 66, 4, 1, 44,
+                           0, 0, 0, 2, 3, 116, 114, 101, 3, 1, 67, 0]);
 
     auto sdbar = sdbar_data.sbinDeserialize!Bar;
 

--- a/example/mir_algebraic_example.d
+++ b/example/mir_algebraic_example.d
@@ -34,6 +34,8 @@ void barTest()
         byte.sizeof + 1 /+ length packed to 1 byte +/ + 3 + // Foo
         byte.sizeof /+ length packed to 1 byte +/ // null
     );
+    assert (sdbar_data == [77, 0, 0, 0, 4, 1, 42, 0, 0, 0, 2, 5, 72,
+                           101, 108, 108, 111, 3, 3, 65, 66, 67, 0]);
     auto sdbar = sdbar_data.sbinDeserialize!Bar;
 
     assert (sdbar.someInt == 77);

--- a/example/sumtype_example.d
+++ b/example/sumtype_example.d
@@ -29,6 +29,7 @@ void barTest()
         byte.sizeof + 1 /+ length packed to 1 byte +/ + 3 + // Foo
         byte.sizeof /+ length packed to 1 byte +/ // null
     );
+    assert (sdbar_data == [77, 0, 0, 0, 4, 1, 42, 0, 0, 0, 2, 5, 72, 101, 108, 108, 111, 3, 3, 65, 66, 67, 0]);
     auto sdbar = sdbar_data.sbinDeserialize!Bar;
 
     assert (sdbar.someInt == 77);

--- a/example/taggedalgebraic_example.d
+++ b/example/taggedalgebraic_example.d
@@ -32,6 +32,7 @@ void barTest()
         byte.sizeof + 1 /+ length packed to 1 byte +/ + 5 + // str
         byte.sizeof + 1 /+ length packed to 1 byte +/ + 3 // Foo
     );
+    assert (sdbar_data == [4, 0, 0, 0, 3, 0, 42, 0, 0, 0, 1, 5, 72, 101, 108, 108, 111, 2, 3, 65, 66, 67]);
     auto sdbar = sdbar_data.sbinDeserialize!Bar;
 
     assert (sdbar.someInt == 4);
@@ -71,6 +72,7 @@ void bar2Test()
         byte.sizeof + 1 /+ length packed to 1 byte +/ + 5 + // str
         byte.sizeof + 1 /+ length packed to 1 byte +/ + 3 // Foo
     );
+    assert (sdbar_data == [3, 0, 42, 0, 0, 0, 1, 5, 72, 101, 108, 108, 111, 2, 3, 65, 66, 67]);
     auto sdbar = sdbar_data.sbinDeserialize!Bar2;
 
     assert (sdbar.data.length == 3);

--- a/source/sbin/ut.d
+++ b/source/sbin/ut.d
@@ -24,7 +24,7 @@ import sbin.deserialize;
     Semantic versioning (semver.org) applies to the binary compatibility of
     APIs, but due to the scope of sbin we also keep the format stable across
     at least minor and patch version increments. Meaning that if the format
-    changes then a major version bump is required.
+    changes then a major version bump is required. See also README.md.
 */
 
 version (unittest) import std.algorithm : equal;


### PR DESCRIPTION
Hi Oleg,

I added assertions on the bytes in all relevant unit tests. This should be a decent guarantee against changes in the format. Please don't be offended by the notes, they are only meant as a friendly reminder :-) Feel free to make changes wherever you want.

The way I did this is I branched off of 0.5.0, added the assertions, then successively rebased to each following release, adding assertions as I went along. So we can be sure that nothing changed in the mean time.

Thanks and take care,
Bastiaan.