### PR TITLE
Support Dub upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,15 +14,13 @@ jobs:
           - dmd-latest
           - ldc-latest
 
-          - dmd-2.097.2
-          - dmd-2.096.1
-          - dmd-2.095.1
-          - dmd-2.094.2
+          - dmd-2.098.1
+          - dmd-2.102.2
+          - dmd-2.106.1
 
-          - ldc-1.27.1
-          - ldc-1.26.0
-          - ldc-1.25.0
-          - ldc-1.24.0
+          - ldc-1.28.1
+          - ldc-1.32.1
+          - ldc-1.36.0
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,10 @@ jobs:
           - ldc-1.28.1
           - ldc-1.32.1
           - ldc-1.36.0
+        exclude:
+          # linker error "section __DATA/__thread_bss has type zero-fill but non-zero file offset"
+          - os: macOS-latest
+            dc: dmd-2.098.1
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/dub.sdl
+++ b/dub.sdl
@@ -13,6 +13,11 @@ dependency "sumtype" version="~>1.1" optional=true
 configuration "default" {
 }
 
+configuration "unittest" {
+    dflags `-allinst`
+}
+
 configuration "allow-raw-unions" {
     versions "allowRawUnions"
+    dflags `-allinst`
 }

--- a/dub.sdl
+++ b/dub.sdl
@@ -6,9 +6,9 @@ license "MIT"
 
 targetType "library"
 
-dependency "taggedalgebraic" version="~>0.11.18" optional=true
-dependency "mir-core" version="~>1.1.54" optional=true
-dependency "sumtype" version="~>1.1.0" optional=true
+dependency "taggedalgebraic" version="~>0.11" optional=true
+dependency "mir-core" version="~>1.1" optional=true
+dependency "sumtype" version="~>1.1" optional=true
 
 configuration "default" {
 }

--- a/example/all_example.d
+++ b/example/all_example.d
@@ -1,7 +1,7 @@
 /+ dub.sdl:
-    dependency "mir-core" version="~>1.1.54"
-    dependency "sumtype" version="~>1.1.0"
-    dependency "taggedalgebraic" version="~>0.11.18"
+    dependency "mir-core" version="~>1.1"
+    dependency "sumtype" version="~>1.1"
+    dependency "taggedalgebraic" version="~>0.11"
     dependency "sbin" path=".."
 +/
 
@@ -13,12 +13,14 @@ import sbin;
 
 struct Foo { string name; }
 
-alias MA = Algebraic!(
-    TaggedType!(typeof(null), "nil"),
-    TaggedType!(int, "count"),
-    TaggedType!(string, "str"),
-    TaggedType!(Foo, "foo"),
-);
+static union U
+{
+    typeof(null) nil;
+    int count;
+    string str;
+    Foo foo;
+}
+alias MA = Algebraic!U;
 
 static assert (isTagged!(MA).any);
 static assert (isTagged!(MA).isMirAlgebraic);

--- a/example/mir_algebraic_example.d
+++ b/example/mir_algebraic_example.d
@@ -1,5 +1,5 @@
 /+ dub.sdl:
-    dependency "mir-core" version="~>1.1.54"
+    dependency "mir-core" version="~>1.1"
     dependency "sbin" path=".."
 +/
 
@@ -8,12 +8,14 @@ import sbin;
 
 struct Foo { string name; }
 
-alias TUnion = Algebraic!(
-    TaggedType!(typeof(null), "nil"),
-    TaggedType!(int, "count"),
-    TaggedType!(string, "str"),
-    TaggedType!(Foo, "foo"),
-);
+static union U
+{
+    typeof(null) nil;
+    int count;
+    string str;
+    Foo foo;
+}
+alias TUnion = Algebraic!U;
 
 static assert (isTagged!(TUnion).any);
 static assert (isTagged!(TUnion).isMirAlgebraic);
@@ -42,7 +44,7 @@ void barTest()
     assert (sdbar.data.length == 4);
     assert (sdbar.data[0].kind == TUnion.Kind.count);
     assert (sdbar.data[0].get!int == 42);
-    //assert (sdbar.data[0].count == 42);
+    assert (sdbar.data[0].count == 42);
 
     // deserialize to new memory
     assert (bar.data[1].get!string.ptr !=
@@ -50,11 +52,11 @@ void barTest()
 
     assert (sdbar.data[1].kind == TUnion.Kind.str);
     assert (sdbar.data[1].get!string == "Hello");
-    //assert (sdbar.data[1].str == "Hello");
+    assert (sdbar.data[1].str == "Hello");
 
     assert (sdbar.data[2].kind == TUnion.Kind.foo);
     assert (sdbar.data[2].get!Foo == Foo("ABC"));
-    //assert (sdbar.data[2].foo == Foo("ABC"));
+    assert (sdbar.data[2].foo == Foo("ABC"));
     assert (sdbar.data[2].get!Foo.name.ptr !=
               bar.data[2].get!Foo.name.ptr);
 

--- a/example/sumtype_example.d
+++ b/example/sumtype_example.d
@@ -1,5 +1,5 @@
 /+ dub.sdl:
-    dependency "sumtype" version="~>1.1.0"
+    dependency "sumtype" version="~>1.1"
     dependency "sbin" path=".."
 +/
 

--- a/example/taggedalgebraic_example.d
+++ b/example/taggedalgebraic_example.d
@@ -1,5 +1,5 @@
 /+ dub.sdl:
-    dependency "taggedalgebraic" version="~>0.11.18"
+    dependency "taggedalgebraic" version="~>0.11"
     dependency "sbin" path=".."
 +/
 

--- a/source/sbin/deserialize.d
+++ b/source/sbin/deserialize.d
@@ -16,7 +16,7 @@ import sbin.repr;
         target = reference to result object
  +/
 void sbinDeserializePart(RH=EmptyReprHandler, R, string file=__FILE__, size_t line=__LINE__, Target...)
-    (ref R range, ref Target target) if (isInputRange!R && is(Unqual!(ElementType!R) == ubyte) && isReprHandler!RH)
+    (scope ref R range, ref Target target) if (isInputRange!R && is(Unqual!(ElementType!R) == ubyte) && isReprHandler!RH)
 {
     import sbin.util.stack : Stack;
 
@@ -273,7 +273,7 @@ void sbinDeserializePart(RH=EmptyReprHandler, R, string file=__FILE__, size_t li
         deserialized value
  +/
 Target sbinDeserializePart(RH=EmptyReprHandler, Target, R, string file=__FILE__, size_t line=__LINE__)
-    (ref R range) if (isReprHandler!RH)
+    (scope ref R range) if (isReprHandler!RH)
 {
     Unqual!Target ret;
     sbinDeserializePart!(RH, R, file, line, Target)(range, ret);
@@ -281,7 +281,7 @@ Target sbinDeserializePart(RH=EmptyReprHandler, Target, R, string file=__FILE__,
 }
 
 /// ditto
-Target sbinDeserializePart(Target, R, string file=__FILE__, size_t line=__LINE__)(ref R range)
+Target sbinDeserializePart(Target, R, string file=__FILE__, size_t line=__LINE__)(scope ref R range)
 {
     Unqual!Target ret;
     sbinDeserializePart!(EmptyReprHandler, R, file, line, Target)(range, ret);
@@ -297,7 +297,7 @@ Target sbinDeserializePart(Target, R, string file=__FILE__, size_t line=__LINE__
         deserialized value
  +/
 Target sbinDeserialize(RH=EmptyReprHandler, Target, R, string file=__FILE__, size_t line=__LINE__)
-    (R range) if (isReprHandler!RH)
+    (scope R range) if (isReprHandler!RH)
 {
     Unqual!Target ret;
     sbinDeserialize!(RH)(range, ret);
@@ -305,7 +305,7 @@ Target sbinDeserialize(RH=EmptyReprHandler, Target, R, string file=__FILE__, siz
 }
 
 /// ditto
-Target sbinDeserialize(Target, R, string file=__FILE__, size_t line=__LINE__)(R range)
+Target sbinDeserialize(Target, R, string file=__FILE__, size_t line=__LINE__)(scope R range)
 {
     Unqual!Target ret;
     sbinDeserialize!(EmptyReprHandler, R, file, line)(range, ret);
@@ -322,7 +322,7 @@ Target sbinDeserialize(Target, R, string file=__FILE__, size_t line=__LINE__)(R 
         SBinDeserializeException if range isn't empty after deseriazlie
  +/
 void sbinDeserialize(RH=EmptyReprHandler, R, string file=__FILE__, size_t line=__LINE__, Target...)
-    (R range, ref Target target) if (isReprHandler!RH)
+    (scope R range, ref Target target) if (isReprHandler!RH)
 {
     sbinDeserializePart!(RH, R, file, line)(range, target);
 


### PR DESCRIPTION
By removing patch information from dependency versions, `dub upgrade` allows minor version upgrades. These, following [semantic versioning](https://semver.org/), should be backward compatible and thus be allowed. This resolves version conflicts for projects that depend on `sbin` and higher minor versions of its dependencies.

Also support the latest compilers.

`TaggedType` was removed in mir-core 1.3.0: https://github.com/libmir/mir-core/commit/3076fa33.
